### PR TITLE
Update Gemfile - gem "nokogiri", "= 1.14.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'jekyll-relative-links'
 gem 'jekyll-spaceship'
 
 gem "webrick", "~> 1.8"
+gem "nokogiri", "= 1.14.2"


### PR DESCRIPTION
Updated gem file to resolve Ruby version error
nokogiri-1.16.2-x86_64-linux requires ruby version < 3.4.dev, >= 3.0, which is incompatible with the current version, ruby 2.7.8p225